### PR TITLE
Add link to the ISO standard for national IBAN formats @ README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Check the demo on [our website] to try it.
 
 [our website]: http://www.arhs-group.com/labs/iban-bban-converter/
 
+IBAN.js follows the [ISO 13616 IBAN Registry technical specification](https://www.swift.com/standards/data-standards/iban).
+
 ## Usage
 
 IBAN.js is compatible with both commonjs and AMD module definition. It can be used as a [node.js module](#in-nodejs) and [in the browser](#in-the-browser). It also has a bower manifest, a [Typescript definition](#with-typescript) and a [Meteor wrapper](#with-meteor-framework).


### PR DESCRIPTION
Since, as explained in [this comment](https://github.com/arhs/iban.js/pull/10#issuecomment-56026219), or implicitly meant in pull requests #21 and #27, we're validating against the technical specification of the ISO 13616 IBAN Registry... we might wanna consider adding this information somewhere/somehow in the README ;)