### PR TITLE
Remove the Array.prototype.map polyfill

### DIFF
--- a/iban.js
+++ b/iban.js
@@ -10,38 +10,6 @@
         factory(root.IBAN = {});
     }
 }(this, function(exports){
-
-    // Array.prototype.map polyfill
-    // code from https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/map
-    if (!Array.prototype.map){
-        Array.prototype.map = function(fun /*, thisArg */){
-            "use strict";
-
-            if (this === void 0 || this === null)
-                throw new TypeError();
-
-            var t = Object(this);
-            var len = t.length >>> 0;
-            if (typeof fun !== "function")
-                throw new TypeError();
-
-            var res = new Array(len);
-            var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
-            for (var i = 0; i < len; i++)
-            {
-                // NOTE: Absolute correctness would demand Object.defineProperty
-                //       be used.  But this method is fairly new, and failure is
-                //       possible only if Object.prototype or Array.prototype
-                //       has a property |i| (very unlikely), so use a less-correct
-                //       but more portable alternative.
-                if (i in t)
-                    res[i] = fun.call(thisArg, t[i], i, t);
-            }
-
-            return res;
-        };
-    }
-
     var A = 'A'.charCodeAt(0),
         Z = 'Z'.charCodeAt(0);
 


### PR DESCRIPTION
I believe libraries should usually not pollute the global namespace and
should therefore also not modify native prototypes.

In addition Array.prototype.map is supported in all modern browsers
(even IE 9 onwards) so I believe this is safe to drop in the end of
2017.

For people who need to support even older browser there are enough
transpiling solutions these days.