### PR TITLE
Fix #53 IBAN specification for Côte d'Ivoire.

### DIFF
--- a/iban.js
+++ b/iban.js
@@ -303,7 +303,7 @@
     // Benin
     addSpecification(new Specification("BJ", 28, "F24",                "BJ39123456789012345678901234"));
     // Ivory
-    addSpecification(new Specification("CI", 28, "U01F23",             "CI17A12345678901234567890123"));
+    addSpecification(new Specification("CI", 28, "U02F22",             "CI70CI1234567890123456789012"));
     // Cameron
     addSpecification(new Specification("CM", 27, "F23",                "CM9012345678901234567890123"));
     // Cape Verde

--- a/test/ibanTest.js
+++ b/test/ibanTest.js
@@ -34,9 +34,13 @@ describe('IBAN', function(){
         it('should return true for a valid Saint-Lucia IBAN', function(){
             expect(IBAN.isValid('LC55HEMM000100010012001200023015')).to.be.true;
         });
-
+        
         it('should return false for an incorrect check digit', function(){
             expect(IBAN.isValid('BE68539007547035')).to.be.false;
+        });
+        
+        it('should return true for a valid Côte d\'Ivoire IBAN', function(){
+            expect(IBAN.isValid('CI93CI0080111301134291200589')).to.be.true;
         });
 
         it('should return true for all examples', function(){


### PR DESCRIPTION
No official source found, but based on various observations online, the BBAN format is different than previously implemented.