### PR TITLE
add structureBlocks to Specification prototype

### DIFF
--- a/iban.js
+++ b/iban.js
@@ -85,6 +85,21 @@
         return parseInt(remainder, 10) % 97;
     }
 
+    /**
+     * @typedef {Object[]} StructureBlocks
+     * @property {string} format
+     * @property {number} repeats
+     */
+
+    /**
+     * Parse the BBAN structure used to configure each IBAN Specification and returns an array of structure blocks.
+     * A structure is composed of blocks of 3 characters (one letter and 2 digits). Each block represents
+     * a logical group in the typical representation of the BBAN. For each group, the letter indicates which characters
+     * are allowed in this group and the following 2-digits number tells the length of the group.
+     *
+     * @param {string} structure the structure to parse
+     * @returns {StructureBlocks}
+     */
     function parseStructureToBlocks(structure){
         // split in blocks of 3 chars
         return structure.match(/(.{3})/g).map(function(block){
@@ -109,12 +124,7 @@
     }
 
     /**
-     * Parse the BBAN structure used to configure each IBAN Specification and returns a matching regular expression.
-     * A structure is composed of blocks of 3 characters (one letter and 2 digits). Each block represents
-     * a logical group in the typical representation of the BBAN. For each group, the letter indicates which characters
-     * are allowed in this group and the following 2-digits number tells the length of the group.
-     *
-     * @param {string} structureBlocks the structureBlocks parsed from structure
+     * @param {StructureBlocks} structureBlocks the structureBlocks parsed from structure
      * @returns {RegExp}
      */
     function parseBlocksToRegex(structureBlocks){

--- a/iban.js
+++ b/iban.js
@@ -87,7 +87,7 @@
 
     /**
      * @typedef {Object[]} StructureBlocks
-     * @property {string} format
+     * @property {string} pattern
      * @property {number} repeats
      */
 
@@ -105,21 +105,21 @@
         return structure.match(/(.{3})/g).map(function(block){
 
             // parse each structure block (1-char + 2-digits)
-            var format,
-                pattern = block.slice(0, 1),
+            var pattern,
+                patternGroup = block.slice(0, 1),
                 repeats = parseInt(block.slice(1), 10);
 
-            switch (pattern){
-                case "A": format = "0-9A-Za-z"; break;
-                case "B": format = "0-9A-Z"; break;
-                case "C": format = "A-Za-z"; break;
-                case "F": format = "0-9"; break;
-                case "L": format = "a-z"; break;
-                case "U": format = "A-Z"; break;
-                case "W": format = "0-9a-z"; break;
+            switch (patternGroup){
+                case "A": pattern = "[0-9A-Za-z]"; break;
+                case "B": pattern = "[0-9A-Z]"; break;
+                case "C": pattern = "[A-Za-z]"; break;
+                case "F": pattern = "[0-9]"; break;
+                case "L": pattern = "[a-z]"; break;
+                case "U": pattern = "[A-Z]"; break;
+                case "W": pattern = "[0-9a-z]"; break;
             }
 
-            return {format, repeats};
+            return {pattern, repeats};
         });
     }
 
@@ -129,7 +129,7 @@
      */
     function parseBlocksToRegex(structureBlocks){
         var regex = structureBlocks.map(function(block){
-            return '([' + block.format + ']{' + block.repeats + '})';
+            return '(' + block.pattern + '{' + block.repeats + '})';
         });
 
         return new RegExp('^' + regex.join('') + '$');

--- a/iban.js
+++ b/iban.js
@@ -119,7 +119,7 @@
                 case "W": pattern = "[0-9a-z]"; break;
             }
 
-            return {pattern, repeats};
+            return {pattern: pattern, repeats: repeats};
         });
     }
 


### PR DESCRIPTION
I need to [reuse](https://github.com/DimaRGB/text-mask-addon-iban/blob/master/src/index.js#L22) structureBlocks, to prevent code duplication.

no effect on current api, just one more **intermediate** Specification method.

example:
---
```
const { VG } = IBAN.countries;

VG.structure === 'U04F16'
VG.structureBlocks() === [{pattern: '[A-Z]', repeats: 4}, {pattern: '[0-9]', repeats: 16}]
```