### PR TITLE
fix debug package vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,15 @@
         }
       }
     },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
     "mocha": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.14.0.tgz",
@@ -46,10 +55,10 @@
       "dev": true,
       "requires": {
         "commander": "2.0.0",
-        "debug": "2.2.0",
+        "debug": "*",
         "diff": "1.0.7",
         "glob": "3.2.3",
-        "growl": "1.7.0",
+        "growl": "1.7.x",
         "jade": "0.26.3",
         "mkdirp": "0.3.5"
       },
@@ -59,23 +68,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
           "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
           "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
         },
         "diff": {
           "version": "1.0.7",
@@ -89,9 +81,9 @@
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
           "dev": true,
           "requires": {
-            "graceful-fs": "2.0.3",
-            "inherits": "2.0.1",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~2.0.0",
+            "inherits": "2",
+            "minimatch": "~0.2.11"
           },
           "dependencies": {
             "graceful-fs": {
@@ -112,8 +104,8 @@
               "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.0",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               },
               "dependencies": {
                 "lru-cache": {
@@ -169,6 +161,12 @@
           "dev": true
         }
       }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
     }
   }
 }


### PR DESCRIPTION
This PR fixes the following npm advisory report:
```
  Low             Regular Expression Denial of Service

  Package         debug

  Dependency of   mocha [dev]

  Path            mocha > debug

  More info       https://npmjs.com/advisories/534
```