### PR TITLE
Made unmaintained status clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![npm version](https://badge.fury.io/js/iban.svg)](https://badge.fury.io/js/iban)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/arhs/iban.js/master/LICENSE)
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
 
 >
-> This library is not maintained anymore
+> This library is not maintained anymore. Perhaps take a look at [ibantools](https://github.com/Simplify/ibantools) as an alternative. It offers added ESM support but uses the MPL license instead of MIT.
 > 
-
-
 
 # iban.js
 


### PR DESCRIPTION
I saw that the master branch was updated to state that the repo is unmaintained.

To make this more obvious I created #88 and I wanted to offer the reader an alternative: [ibantools](https://github.com/Simplify/ibantools), thanks to [@QSaws](https://github.com/arhs/iban.js/issues/81#issuecomment-791418389).

I would also like to ask @itoche to take a look at how to [deprecate a package on NPM](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions] and ask him to do that so current users will be warned about the unmaintained state of the project upon install.

I would suggest the following:

`npm deprecate iban "This project is no longer maintained. For a maintained project with ESM support, check out ibantools"`